### PR TITLE
Provide compatibility with Eclipse Leshan OBSERVE request

### DIFF
--- a/lib/coap-node.js
+++ b/lib/coap-node.js
@@ -730,8 +730,10 @@ CoapNode.prototype._enableReport = function (oid, iid, rid, rsp, callback) {
 
             val = cutils.encodeJson(key, rAttrs.lastRpVal);
         } else {
-            val = val.toString();
             rAttrs.lastRpVal = val;
+            // For Eclipse Leshan compatibility, the value should be sent 
+            // as TLV encoded instead of UTF
+            val = cutils.encodeTlv(key, val);
         }
 
         try {


### PR DESCRIPTION
Observe on client resources doesn't work currently with Eclipse Leshan. The server expects OBSERVE notification to be TLV encoded instead of UTF8. 
